### PR TITLE
fix: build failed on apple-silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 # general
 option(BERT_STATIC                 "bert: static link libraries"                          OFF)
-option(BERT_NATIVE                 "bert: enable -march=native flag"                      ON)
+option(BERT_NATIVE                 "bert: enable -march=native flag"                       OFF)
 option(BERT_LTO                    "bert: enable link time optimization"                  OFF)
 
 # debug

--- a/bert.cpp
+++ b/bert.cpp
@@ -15,6 +15,11 @@
 #include <thread>
 #include <algorithm>
 
+// if using clang under macos, use unordered_map
+#if defined(__APPLE__)
+#include <unordered_map>
+#endif
+
 // default hparams (all-MiniLM-L6-v2)
 struct bert_hparams
 {


### PR DESCRIPTION
Hi, I failed cmake build on apple silicon, and this should fix it. 
1. by default, we shouldnt add -march=native flag on macos build
2. clang need include unordered_map