### PR TITLE
fix: compile error without header

### DIFF
--- a/bert.cpp
+++ b/bert.cpp
@@ -14,6 +14,7 @@
 #include <regex>
 #include <thread>
 #include <algorithm>
+#include <unordered_map>
 
 // if using clang under macos, use unordered_map
 #if defined(__APPLE__)


### PR DESCRIPTION
A trivial compile erro on my arm64 machine with gcc 12.2.1 master@cd1e6ddf7:
```
[  8%] Building C object ggml/src/CMakeFiles/ggml.dir/ggml.c.o
[ 16%] Linking C static library libggml.a
[ 16%] Built target ggml
[ 25%] Building CXX object CMakeFiles/bert.dir/bert.cpp.o
/home/wesley/WorkPlace/chatGPT/bert.cpp/bert.cpp: In function ‘std::string stripAccents(const std::string&)’:
/home/wesley/WorkPlace/chatGPT/bert.cpp/bert.cpp:215:10: error: ‘unordered_map’ is not a member of ‘std’
  215 |     std::unordered_map<std::string, char> accentMap = {{"À", 'A'},{"Á", 'A'},
      |          ^~~~~~~~~~~~~
/home/wesley/WorkPlace/chatGPT/bert.cpp/bert.cpp:17:1: note: ‘std::unordered_map’ is defined in header ‘<unordered_map>’; did you forget to ‘#include <unordered_map>’?
   16 | #include <algorithm>
  +++ |+#include <unordered_map>

```