### PR TITLE
-lrt required for some versions of ld

### DIFF
--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,2 +1,3 @@
+link_libraries("-lrt")
 add_executable(quantize quantize.cpp)
 target_link_libraries(quantize PRIVATE bert ggml)


### PR DESCRIPTION
Some versions of ld are causing the following issue: undefined reference to `clock_gettime'

https://stackoverflow.com/questions/2418157/c-error-undefined-reference-to-clock-gettime-and-clock-settime

Can be replicated with "conda install -c conda-forge gxx_linux-64", which uses "GNU ld (GNU Binutils) 2.39".